### PR TITLE
matplotlib2tikz renamed

### DIFF
--- a/data/plotting.py
+++ b/data/plotting.py
@@ -15,7 +15,7 @@ import matplotlib.pyplot as plt
 #from matplotlib.ticker import MultipleLocator, FuncFormatter
 
 import pandas as pd
-import matplotlib2tikz
+import tikzplotlib
 
 os.chdir('/Users/farismismar/Desktop/deep/')
 


### PR DESCRIPTION
As described in https://pypi.org/project/matplotlib2tikz/
"matplotlib2tikz has been renamed to tikzplotlib. matplotlib2tikz will no longer be supported."